### PR TITLE
Fixed the SelectArea issue for custom Sample Attributes.

### DIFF
--- a/limbus/app/dynform/__init__.py
+++ b/limbus/app/dynform/__init__.py
@@ -40,7 +40,7 @@ class DynamicAttributeFormGenerator:
                 setattr(
                     self._form,
                     p.number_to_words(attr.id),
-                    SelectField(attr.term, choices=[(x.term, x.id) for x in options]),
+                    SelectField(attr.term, coerce=int, choices=[(x.id, x.term) for x in options]),
                 )
 
     def _inject_submit(self):


### PR DESCRIPTION
Finally got around to resolving a long-standing issue that we've had since early alpha version.

Custom Option Sample Attributes now render and validate correctly on add Sample.

![Screenshot](https://i.imgur.com/3sxmyY4.png)