### PR TITLE
Temporary Administration Panel

### DIFF
--- a/limbus/app/__init__.py
+++ b/limbus/app/__init__.py
@@ -6,13 +6,12 @@ from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy_continuum import make_versioned
 from flask_login import LoginManager
 from flask_migrate import Migrate
-from flask_admin import Admin
 
 db = SQLAlchemy()
 login_manager = LoginManager()
-app_admin = Admin(name="Administrator Panel", template_mode="bootstrap3")
 
 # blueprint imports
+from .admin import admin as admin_blueprint
 from .misc import misc as misc_blueprint
 from .attribute import attribute as attribute_blueprint
 from .setup import setup as setup_blueprint
@@ -28,6 +27,7 @@ from .storage import storage as storage_blueprint
 def create_app():
     app = Flask(__name__, instance_relative_config=True)
 
+
     app.config.from_object(app_config[os.getenv("FLASK_CONFIG")])
     app.config.from_pyfile("config.py")
 
@@ -40,7 +40,7 @@ def create_app():
 
     migrate = Migrate(app, db)
 
-    app_admin.init_app(app)
+
 
     # Load in models here
     from app.auth import models as auth_models
@@ -53,8 +53,9 @@ def create_app():
     from app.attribute import models as attribute_models
 
     app.register_blueprint(misc_blueprint)
-    app.register_blueprint(setup_blueprint, url_prefix="/setup")
     app.register_blueprint(auth_blueprint)
+    app.register_blueprint(setup_blueprint, url_prefix="/setup")
+    app.register_blueprint(admin_blueprint, url_prefix="/admin")
     app.register_blueprint(attribute_blueprint, url_prefix="/attributes")
     app.register_blueprint(processing_blueprint, url_prefix="/processing")
     app.register_blueprint(doc_blueprint, url_prefix="/documents")
@@ -63,9 +64,6 @@ def create_app():
     app.register_blueprint(pcf_blueprint, url_prefix="/pcf")
     app.register_blueprint(storage_blueprint, url_prefix="/storage")
 
-    from app.admin import add_admin_views
-
-    add_admin_views()
 
     @app.errorhandler(404)
     def page_not_found(e):

--- a/limbus/app/admin/__init__.py
+++ b/limbus/app/admin/__init__.py
@@ -1,1 +1,5 @@
-from .views import add_admin_views
+from flask import Blueprint
+
+admin = Blueprint("admin", __name__)
+
+from . import routes

--- a/limbus/app/admin/forms.py
+++ b/limbus/app/admin/forms.py
@@ -16,8 +16,6 @@ from ..auth.models import User
 from ..misc.models import BiobankInformation
 
 
-
-
 class TemporaryRegistrationForm(FlaskForm):
 
 
@@ -42,6 +40,7 @@ class TemporaryRegistrationForm(FlaskForm):
         ],
     )
 
+   
 
     confirm_password = PasswordField("Confirm Password")
 

--- a/limbus/app/admin/forms.py
+++ b/limbus/app/admin/forms.py
@@ -1,0 +1,52 @@
+
+from flask_wtf import FlaskForm
+from wtforms import (
+    PasswordField,
+    StringField,
+    SubmitField,
+    ValidationError,
+    SelectField,
+)
+from wtforms.validators import DataRequired, Email, EqualTo
+
+from ..auth.enums import Title
+
+
+from ..auth.models import User
+from ..misc.models import BiobankInformation
+
+
+
+
+class TemporaryRegistrationForm(FlaskForm):
+
+
+    title = SelectField("Title", validators=[DataRequired()], choices=Title.choices())
+
+    first_name = StringField("First Name", validators=[DataRequired()])
+    middle_name = StringField("Middle Name")
+    last_name = StringField("Last Name", validators=[DataRequired()])
+
+    email = StringField(
+        "Email Address",
+        description="We'll never share your email with anyone else.",
+        validators=[DataRequired(), Email()],
+    )
+
+    password = PasswordField(
+        "Password",
+        description="Please ensure that you provide a secure password",
+        validators=[
+            DataRequired(),
+            EqualTo("confirm_password", message="Passwords must match"),
+        ],
+    )
+
+
+    confirm_password = PasswordField("Confirm Password")
+
+    submit = SubmitField("Register")
+
+    def validate_email(self, field):
+        if User.query.filter_by(email=field.data).first():
+            raise ValidationError("Email address already in use.")

--- a/limbus/app/admin/routes.py
+++ b/limbus/app/admin/routes.py
@@ -14,7 +14,7 @@ from functools import wraps
 def check_if_admin(f):
     @wraps(f)
     def decorated_function(*args, **kwargs):
-        if db.session.query(User).filter(User.id == current_user.id).first().is_admin:
+        if current_user.is_admin:
             return f(*args, **kwargs)
         return abort(401)
     return decorated_function

--- a/limbus/app/admin/routes.py
+++ b/limbus/app/admin/routes.py
@@ -1,0 +1,17 @@
+from . import admin
+from .. import db
+
+from flask import render_template
+
+from .forms import TemporaryRegistrationForm
+from .views import UserAccountsView
+
+@admin.route("/", methods=["GET", "POST"])
+def index():
+    form = TemporaryRegistrationForm()
+
+    accounts = UserAccountsView()
+
+    if form.validate_on_submit():
+        return "Submitted"
+    return render_template("admin/index.html", form=form, accounts=accounts)

--- a/limbus/app/admin/routes.py
+++ b/limbus/app/admin/routes.py
@@ -1,17 +1,47 @@
 from . import admin
 from .. import db
 
-from flask import render_template
+from flask import render_template, url_for, redirect, abort
+from flask_login import current_user
 
 from .forms import TemporaryRegistrationForm
 from .views import UserAccountsView
 
+from ..auth.models import Profile, User
+
+from functools import wraps
+
+def check_if_admin(f):
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        if db.session.query(User).filter(User.id == current_user.id).first().is_admin:
+            return f(*args, **kwargs)
+        return abort(401)
+    return decorated_function
+
 @admin.route("/", methods=["GET", "POST"])
+@check_if_admin
 def index():
     form = TemporaryRegistrationForm()
 
     accounts = UserAccountsView()
 
     if form.validate_on_submit():
-        return "Submitted"
+        
+        profile = Profile(
+            title=form.title.data,
+            first_name=form.first_name.data,
+            middle_name=form.middle_name.data,
+            last_name=form.last_name.data,
+        )
+
+        db.session.add(profile)
+        db.session.flush()
+
+        user = User(email=form.email.data, password=form.password.data, is_admin=False, profile_id=profile.id)
+        db.session.add(user)
+        db.session.commit()
+
+        return redirect(url_for("admin.index"))
+
     return render_template("admin/index.html", form=form, accounts=accounts)

--- a/limbus/app/admin/views.py
+++ b/limbus/app/admin/views.py
@@ -1,17 +1,13 @@
-from functools import wraps
+from .routes import db
+from ..auth.models import User, Profile
+from ..auth.views import UserView
 
-from flask import redirect, render_template, url_for, flash, abort
-from flask_admin.contrib.sqla import ModelView
+def UserAccountsView() -> dict:
+    users = db.session.query(User, Profile).filter(User.profile_id == Profile.id).all()
 
-from .. import db
-from ..auth.models import User
+    data = {}
 
+    for user, profile in users:
+        data[user.id] = UserView(user.id, [user, profile])
 
-class UserView(ModelView):
-    column_exclude_list = ["password_hash"]
-
-
-def add_admin_views():
-    from .. import app_admin
-
-    app_admin.add_view(UserView(User, db.session))
+    return data

--- a/limbus/app/auth/views.py
+++ b/limbus/app/auth/views.py
@@ -19,11 +19,15 @@ def UserIndexView() -> dict:
     return data
 
 
-def UserView(id: int) -> dict:
-    user, profile = db.session.query(
-        User,
-        Profile
-    ).filter(User.id == id).filter(Profile.id == User.profile_id).first_or_404()
+def UserView(id: int, user_profile: list = None) -> dict:
+
+    if user_profile == None:
+        user, profile = db.session.query(
+            User,
+            Profile
+        ).filter(User.id == id).filter(Profile.id == User.profile_id).first_or_404()
+    else:
+        user, profile = user_profile
 
     return {
         "id": user.id,

--- a/limbus/app/templates/admin/index.html
+++ b/limbus/app/templates/admin/index.html
@@ -1,0 +1,66 @@
+{% extends "template.html" %}
+
+
+{% block title %}User Accounts : Admin Portal{% endblock %}
+
+
+{% block body %}
+
+<div class="container">
+
+    <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pb-2 mb-3 border-bottom">
+        <h2><i class="fa fa-user"></i> User Accounts</h2>
+        <div class="btn-toolbar">
+            <div class="btn-group mr-2">
+                <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#exampleModal">
+                    <i class="fas fa-plus"></i> Add Account
+                </button>
+            </div>
+        </div>
+    </div>
+
+
+    <div class="alert alert-danger text-center">
+        <i class="fa fa-exclamation-triangle"></i> <b>Notice:</b> This is a temporary administration panel.
+        </div>
+
+        {% for uid, account in accounts.items() %}
+            {{ account }}
+        {% endfor %}
+</div>
+
+
+
+<!-- Modal -->
+<div class="modal fade" id="exampleModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="exampleModalLabel">Add Account</h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body">
+          <form method="POST" action="{{ url_for('admin.index' ) }}">
+              {{form.csrf_token()}}
+              {{form_field(form.title)}}
+              {{form_field(form.first_name)}}
+              {{form_field(form.middle_name)}}
+              {{form_field(form.last_name)}}
+
+              {{form_field(form.email)}}
+              {{form_field(form.password)}}
+              {{form_field(form.confirm_password)}}
+        </div>
+        <div class="modal-footer">
+          {{form_field(form.submit)}}
+        </form>
+
+        </div>
+      </div>
+    </div>
+  </div>
+
+
+{% endblock %}

--- a/limbus/app/templates/admin/index.html
+++ b/limbus/app/templates/admin/index.html
@@ -21,12 +21,35 @@
 
 
     <div class="alert alert-danger text-center">
-        <i class="fa fa-exclamation-triangle"></i> <b>Notice:</b> This is a temporary administration panel.
+        <i class="fa fa-exclamation-triangle"></i> <b>Notice:</b> This is a temporary administration panel. At the moment, all you can do is create users, and that's about it.
+        This will be extended in the future to provide functionality expected of a production grade admininistration panel.
         </div>
 
-        {% for uid, account in accounts.items() %}
-            {{ account }}
-        {% endfor %}
+        <table id="accountTable" class="table table-striped table-bordered" style="width:100%">
+          <thead>
+          <tr>
+              <th>Email Address</th>
+              <th>Admin</th>
+              <th>Is Locked</th>
+              <th>Creation Date</th>
+              <th>Actions</th>
+          </tr>
+          </thead>
+          <tbody>
+            {% for uid, account in accounts.items() %}
+            <tr>
+              <td>{{account.email}}</td>
+              <td>{{account.is_admin}}</td>
+              <td>{{account.is_locked}}</td>
+              <td>{{account.creation_date}}</td>
+              <td></td>
+            </tr>
+          {% endfor %}
+          
+          </tbody>
+      </table>
+
+       
 </div>
 
 


### PR DESCRIPTION
I've not had time to fully get my head around ```flask-admin``` (help needed), so a temporary solution was to just implement a temporary administration panel that - for now - allows the administrator to create non admin user accounts using a simple form.

Here's the administration panel once you open it up.

![image](https://user-images.githubusercontent.com/4386515/81134391-79161c00-8f4c-11ea-98e9-9d66372b0dfd.png)

You can then create an user account using this simple modal.

![image](https://user-images.githubusercontent.com/4386515/81134413-8fbc7300-8f4c-11ea-94cc-0b04226dc1b4.png)

This needs to be extended massively for full release, but for now it'll suffice.