### PR TITLE
Nicer security headers

### DIFF
--- a/services/web/app/__init__.py
+++ b/services/web/app/__init__.py
@@ -5,6 +5,7 @@ from config import app_config
 from flask_sqlalchemy import SQLAlchemy
 from flask_login import LoginManager
 from flask_migrate import Migrate
+from flask_talisman import Talisman
 
 from sqlalchemy import orm
 
@@ -31,10 +32,11 @@ from .processing import processing as processing_blueprint
 from .storage import storage as storage_blueprint
 from .procedure import procedure as procedure_blueprint
 
+from .csp import csp
 
 def create_app():
     app = Flask(__name__, instance_relative_config=True)
-
+    Talisman(app, content_security_policy=csp, content_security_policy_nonce_in=None,)    
     app.config.from_object(app_config[os.environ["FLASK_CONFIG"]])
     app.config.from_pyfile("config.py")
 

--- a/services/web/app/csp.py
+++ b/services/web/app/csp.py
@@ -1,0 +1,47 @@
+SELF = "'self\'"
+UNSAFE = "'unsafe-inline\'"
+
+csp = {
+    'font-src': [
+        SELF,
+        UNSAFE,
+        'themes.googleusercontent.com',
+        '*.gstatic.com',
+        # Google Fonts
+        'https://fonts.gstatic.com'
+    ],
+    'img-src': [
+        SELF,
+        UNSAFE,
+        '*.bootstrapcdn.com',
+        '*.googleapis.com',
+        'https://www.gravatar.com',
+    ],
+    'style-src': [
+        SELF,
+        UNSAFE,
+        'stackpath.bootstrapcdn.com',
+        'fonts.googleapis.com',
+        'ajax.googleapis.com',
+        '*.gstatic.com',
+        '*',
+    ],
+    'script-src': [
+        SELF,
+        UNSAFE,
+        'https://maxcdn.bootstrapcdn.com',
+        'https://code.jquery.com',
+        'https://www.google.com', 
+        'ajax.googleapis.com',
+    ],
+    'frame-src': [
+        UNSAFE,
+        SELF,
+        'www.google.com',
+        'www.youtube.com',
+    ],
+    'default-src': [
+        UNSAFE,
+        SELF,
+    ],
+}

--- a/services/web/requirements.txt
+++ b/services/web/requirements.txt
@@ -9,6 +9,7 @@ Flask==1.1.2
 Flask-Login==0.5.0
 Flask-Migrate==2.5.3
 Flask-SQLAlchemy==2.4.1
+flask-talisman==0.7.0
 Flask-WTF==0.14.3
 frozendict==1.2
 gunicorn==20.0.4


### PR DESCRIPTION
This is a nice little PR that does the following:

- All connects are now forced to HTTPS by default. If you would like to turn this off, you have to enable debug in the config.
- HTTP strict transport security is now forced.
- X-Frame-Options have now been set to SAMEORIGIN to avoid clickjacking.
- X-XSS-Protection has been set to give those unfortunate to use IE the same level of protection us Firefox users are afforded.

CSPs can now be modified by an administrator within services/web/app/csp.py, which is then loaded into the web service upon instantiation.