### PR TITLE
Added Sample Disposal Event 

### DIFF
--- a/services/web/app/api/filters.py
+++ b/services/web/app/api/filters.py
@@ -14,8 +14,10 @@ def _post():
 
 
 def get_filters_and_joins(args: dict, model):
+
     filters = {}
     joins = []
+
     for key, value in args.items():
         if type(value) == dict:
             joins.append(getattr(model, key).has(**value))

--- a/services/web/app/attribute/api.py
+++ b/services/web/app/attribute/api.py
@@ -61,7 +61,6 @@ def attribute_home(tokenuser: UserAccount):
 @use_args(AttributeSearchSchema(), location="json")
 @token_required
 def attribute_query(args, tokenuser: UserAccount):
-    print(args)
 
     filters, joins = get_filters_and_joins(args, Attribute)
 

--- a/services/web/app/misc/__init__.py
+++ b/services/web/app/misc/__init__.py
@@ -15,6 +15,7 @@
 
 
 from flask import Blueprint
+import inspect
 
 misc = Blueprint("misc", __name__)
 
@@ -32,6 +33,8 @@ def clear_session(hash: str) -> None:
 
 def get_internal_api_header(tokenuser=None):
 
+    print("\tCalled from: ", inspect.stack()[1][3])
+
     if tokenuser == None:
         email = current_user.email
     else:
@@ -40,4 +43,8 @@ def get_internal_api_header(tokenuser=None):
     return {"FlaskApp": current_app.config.get("SECRET_KEY"), "Email": email}
 
 
+
+
+
 from .routes import *
+from .types import flask_return_union

--- a/services/web/app/misc/types.py
+++ b/services/web/app/misc/types.py
@@ -1,0 +1,56 @@
+# Copyright (C) 2021 Keiron O'Shea <keo7@aber.ac.uk>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+# Decided that it'd be nice to have some form of type hinting, this Union
+# annotation represents all possible Flask views. Unfortunately, Flask doesn't
+# return any any type hinting - so this sorta does it.
+
+import typing
+from werkzeug.datastructures import Headers
+from werkzeug.wrappers import BaseResponse
+
+_str_bytes = typing.Union[str, bytes]
+_data_type = typing.Union[
+    _str_bytes,
+    BaseResponse,
+    typing.Dict[str, typing.Any],
+    typing.Callable[
+        [typing.Dict[str, typing.Any],
+        typing.Callable[
+            [
+                str, typing.List[typing.Tuple[str, str]]]
+                , None
+                ]
+                ],
+                typing.Iterable[bytes]
+    ],
+]
+
+_status_type = typing.Union[int, _str_bytes]
+_headers_type = typing.Union[
+    Headers, 
+    typing.Dict[_str_bytes, _str_bytes],
+    typing.Iterable[
+        typing.Tuple[_str_bytes, _str_bytes]
+        ],
+]
+
+flask_return_union = typing.Union[
+    _data_type,
+    typing.Tuple[_data_type],
+    typing.Tuple[_data_type, _status_type],
+    typing.Tuple[_data_type, _headers_type],
+    typing.Tuple[_data_type, _status_type, _headers_type],
+]

--- a/services/web/app/protocol/api.py
+++ b/services/web/app/protocol/api.py
@@ -52,7 +52,11 @@ def protocol_home(tokenuser: UserAccount):
 @use_args(ProtocolTemplateSearchSchema(), location="json")
 @token_required
 def protocol_query(args, tokenuser: UserAccount):
+
     filters, joins = get_filters_and_joins(args, ProtocolTemplate)
+
+    
+
     return success_with_content_response(
         basic_protocol_templates_schema.dump(
             ProtocolTemplate.query.filter_by(**filters).filter(*joins).all()

--- a/services/web/app/protocol/views.py
+++ b/services/web/app/protocol/views.py
@@ -42,7 +42,7 @@ class ProtocolTemplateSearchSchema(masql.SQLAlchemySchema):
 
     id = masql.auto_field(required=False)
     name = masql.auto_field(required=False)
-    type = EnumField(ProtocolType, required=False)
+    type = fields.List(EnumField(ProtocolType, required=False))
     author = ma.Nested(UserAccountSearchSchema)
     is_locked = masql.auto_field(required=False)
 

--- a/services/web/app/sample/api/disposal.py
+++ b/services/web/app/sample/api/disposal.py
@@ -18,16 +18,17 @@ from marshmallow import ValidationError
 from ...api import api, generics
 from ...api.responses import *
 from ...decorators import token_required
-from ...misc import get_internal_api_header
+from ...misc import get_internal_api_header, flask_return_union
 
-from ..views import new_sample_disposal_schema, basic_disposal_schema
+from ..views import new_sample_disposal_schema, basic_disposal_schema, new_sample_disposal_event_schema, basic_sample_disposal_event_schema
 
-from ...database import db, SampleDisposal, UserAccount
+from ...database import db, SampleDisposal, UserAccount, SampleDisposalEvent, Sample
 
+import requests
 
 @api.route("/sample/new/disposal_instructions", methods=["POST"])
 @token_required
-def sample_new_disposal_instructions(tokenuser: UserAccount):
+def sample_new_disposal_instructions(tokenuser: UserAccount) -> flask_return_union:
     values = request.get_json()
 
     if not values:
@@ -51,3 +52,74 @@ def sample_new_disposal_instructions(tokenuser: UserAccount):
         )
     except Exception as err:
         return transaction_error_response(err)
+
+    
+@api.route("/sample/new/disposal_event", methods=["POST"])
+@token_required
+def sample_new_disposal_event(tokenuser: UserAccount) -> flask_return_union:
+    values: dict = request.get_json()
+
+    if not values:
+        return no_values_response()
+
+    sample_response = requests.get(
+        url_for("api.sample_view_sample", uuid=values["sample_uuid"], _external=True),
+        headers=get_internal_api_header(tokenuser),
+    )
+
+    if sample_response.status_code == 200:
+
+        new_protocol_event_response = requests.post(
+                url_for("api.sample_new_sample_protocol_event", _external=True),
+                headers=get_internal_api_header(tokenuser),
+                json={
+                    "datetime": values["datetime"],
+                    "undertaken_by": values["undertaken_by"],
+                    "comments": values["comments"],
+                    "protocol_id": values["protocol_id"],
+                    "sample_id": sample_response.json()["content"]["id"],
+                },
+            )
+
+        if new_protocol_event_response.status_code == 200:
+
+            try:
+                disposal_event_values = new_sample_disposal_event_schema.load({
+                            "sample_id": sample_response.json()["content"]["id"],
+                            "reason": values["reason"]})           
+            except ValidationError as err:
+                return validation_error_response(err)
+            
+            new_disposal_event = SampleDisposalEvent(**disposal_event_values)
+            new_disposal_event.author_id = tokenuser.id
+
+            try:
+                
+
+                db.session.add(new_disposal_event)
+                db.session.commit()
+                db.session.flush()
+
+                sample = Sample.query.filter_by(uuid=sample_response.json()["content"]["uuid"]).first()
+
+                if new_disposal_event.reason in ["DES", "FAI"]:
+                    sample.status = "DES"
+                elif new_disposal_event.reason == "TRA":
+                    sample.status = "TRA"
+                elif new_disposal_event.reason == "UNA":
+                    sample.status = "MIS"
+                else:
+                    sample.status = "UNU"
+
+                db.session.add(sample)
+                db.session.commit()
+
+                return success_with_content_response(
+                    basic_sample_disposal_event_schema.dump(new_disposal_event)
+                )
+
+            except Exception as err:
+                return transaction_error_response(err)
+
+        else:
+            return new_protocol_event_response.response

--- a/services/web/app/sample/enums.py
+++ b/services/web/app/sample/enums.py
@@ -126,6 +126,12 @@ class TissueSampleType(FormEnum):
     FROTS = "Frozen Tissue Slide"
     MDS = "Microdissected"
 
+class DisposalReason(FormEnum):
+    DES = "Procedural"
+    FAI = "Failed Sample Review"
+    TRA = "Transferred"
+    UNA = "Not Retrievable"
+    UNK = "Unknown"
 
 class DisposalInstruction(FormEnum):
     NAP = "No Disposal"

--- a/services/web/app/sample/forms/__init__.py
+++ b/services/web/app/sample/forms/__init__.py
@@ -19,3 +19,4 @@ from .document import *
 from .filter import *
 from .review import *
 from .protocol import *
+from .disposal import *

--- a/services/web/app/sample/forms/disposal.py
+++ b/services/web/app/sample/forms/disposal.py
@@ -16,28 +16,41 @@
 
 from flask_wtf import FlaskForm
 from wtforms.validators import DataRequired, Optional
-from wtforms import SelectField, SubmitField, DateField, TimeField, TextAreaField
-from ..enums import DisposalInstruction
+from wtforms import SelectField, SubmitField, DateField, TimeField, TextAreaField, StringField
+from ..enums import DisposalReason
 from datetime import datetime
 
-class SampleDisposalForm(FlaskForm):
+def SampleDisposalEventForm(protocols: list) -> FlaskForm:
+    class StaticForm(FlaskForm):
+        protocol_id = SelectField("Protocol", choices=protocols, coerce=int)
 
-    instruction = SelectField("Disposal Instructions", choices=DisposalInstruction.choices())
-    comments = TextAreaField("Comments")
+        reason = SelectField(
+            "Disposal Reason",
+            description="Reason for disposal",
+            choices=DisposalReason.choices()
+            )
+        
+        comments = TextAreaField("Comments")
 
-    date = DateField(
-            "Disposal Event Date",
+        date = DateField(
+                "Disposal Event Date",
+                validators=[DataRequired()],
+                description="The date in which the disposal was undertaken.",
+                default=datetime.today(),
+            )
+
+        time = TimeField(
+            "Disposal Event Time",
+            default=datetime.now(),
             validators=[DataRequired()],
-            description="The date in which the disposal was undertaken.",
-            default=datetime.today(),
+            description="The time at which the disposal was undertaken.",
         )
 
-    time = TimeField(
-        "Disposal Event Time",
-         default=datetime.now(),
-        validators=[Optional()],
-        description="The time at which the disposal was undertaken.",
-    )
+        undertaken_by = StringField(
+            "Undertaken By",
+            description="The initials of the individual who undertook the disposal event.",
+        )
 
-    submit = SubmitField("Submit")
-
+        submit = SubmitField("Submit")
+    
+    return StaticForm()

--- a/services/web/app/sample/forms/disposal.py
+++ b/services/web/app/sample/forms/disposal.py
@@ -1,0 +1,43 @@
+# Copyright (C) 2021 Keiron O'Shea <keo7@aber.ac.uk>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+from flask_wtf import FlaskForm
+from wtforms.validators import DataRequired, Optional
+from wtforms import SelectField, SubmitField, DateField, TimeField, TextAreaField
+from ..enums import DisposalInstruction
+from datetime import datetime
+
+class SampleDisposalForm(FlaskForm):
+
+    instruction = SelectField("Disposal Instructions", choices=DisposalInstruction.choices())
+    comments = TextAreaField("Comments")
+
+    date = DateField(
+            "Disposal Event Date",
+            validators=[DataRequired()],
+            description="The date in which the disposal was undertaken.",
+            default=datetime.today(),
+        )
+
+    time = TimeField(
+        "Disposal Event Time",
+         default=datetime.now(),
+        validators=[Optional()],
+        description="The time at which the disposal was undertaken.",
+    )
+
+    submit = SubmitField("Submit")
+

--- a/services/web/app/sample/forms/filter.py
+++ b/services/web/app/sample/forms/filter.py
@@ -15,7 +15,7 @@
 
 
 from flask_wtf import FlaskForm
-from wtforms import SelectField, StringField, SubmitField
+from wtforms import SelectField, StringField, SubmitField, BooleanField
 from ..enums import Colour, BiohazardLevel, SampleSource, SampleStatus, SampleBaseType
 
 

--- a/services/web/app/sample/models/base.py
+++ b/services/web/app/sample/models/base.py
@@ -108,3 +108,6 @@ class SampleDisposal(Base, RefAuthorMixin, RefEditorMixin):
     instruction = db.Column(db.Enum(DisposalInstruction))
     comments = db.Column(db.Text)
     disposal_date = db.Column(db.Date, nullable=True)
+
+class SampleDisposalEvent(Base, RefAuthorMixin, RefEditorMixin):
+    pass

--- a/services/web/app/sample/models/base.py
+++ b/services/web/app/sample/models/base.py
@@ -22,6 +22,7 @@ from ..enums import (
     Colour,
     SampleSource,
     BiohazardLevel,
+    DisposalReason,
 )
 
 
@@ -76,6 +77,11 @@ class Sample(Base, UniqueIdentifierMixin, RefAuthorMixin, RefEditorMixin):
         viewonly=True,
     )
 
+    disposal_event = db.relationship(
+        "SampleDisposalEvent",
+        primaryjoin="Sample.id==SampleDisposalEvent.sample_id"
+    )
+
     parent = db.relationship(
         "Sample",
         secondary="subsampletosample",
@@ -110,4 +116,6 @@ class SampleDisposal(Base, RefAuthorMixin, RefEditorMixin):
     disposal_date = db.Column(db.Date, nullable=True)
 
 class SampleDisposalEvent(Base, RefAuthorMixin, RefEditorMixin):
-    pass
+    __versioned__ = {}
+    reason = db.Column(db.Enum(DisposalReason))
+    sample_id = db.Column(db.Integer, db.ForeignKey("sample.id"), unique=True, primary_key=True)

--- a/services/web/app/sample/routes/aliquot.py
+++ b/services/web/app/sample/routes/aliquot.py
@@ -33,7 +33,7 @@ def aliquot(uuid: str):
     protocol_response = requests.get(
         url_for("api.protocol_query", _external=True),
         headers=get_internal_api_header(),
-        json={"is_locked": False, "type": "ALD"},
+        json={"is_locked": False, "type": ["ALD"]},
     )
 
     if protocol_response.status_code != 200:

--- a/services/web/app/sample/routes/dispose.py
+++ b/services/web/app/sample/routes/dispose.py
@@ -14,13 +14,15 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from .. import sample
-from flask import render_template, url_for, flash, session, redirect
+from flask import render_template, url_for, flash, session, redirect, abort
 from flask_login import login_required
 
 from ...misc import get_internal_api_header
 import requests
 
 from uuid import uuid4
+
+from ..forms import SampleDisposalForm
 
 
 @sample.route("<uuid>/dispose", methods=["GET", "POST"])
@@ -32,7 +34,13 @@ def dispose(uuid: str) -> str:
     )
 
     if sample_response.status_code == 200:
+
+        form = SampleDisposalForm()
+
         return render_template(
             "sample/disposal/new.html",
-            sample=sample_response.json()["content"]
-    )
+            sample=sample_response.json()["content"],
+            form=form
+        )
+    else:
+        abort(sample_response.status_code)

--- a/services/web/app/sample/views/disposal.py
+++ b/services/web/app/sample/views/disposal.py
@@ -14,18 +14,38 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from ...extensions import ma
-from ...database import SampleDisposal
+from ...database import SampleDisposal, SampleDisposalEvent
 
 from ...consent.views import (
     BasicConsentFormQuestionSchema,
     BasicConsentFormTemplateSchema,
 )
 
-from ..enums import DisposalInstruction
+from ..enums import DisposalInstruction, DisposalReason
 
 import marshmallow_sqlalchemy as masql
 from marshmallow_enum import EnumField
 
+
+class NewSampleDiposalEventSchema(masql.SQLAlchemySchema):
+    class Meta:
+        model = SampleDisposalEvent
+
+    reason = EnumField(DisposalReason)
+    sample_id = masql.auto_field()
+
+new_sample_disposal_event_schema = NewSampleDiposalEventSchema()
+
+
+class BasicSampleDiposalEventSchema(masql.SQLAlchemySchema):
+    class Meta:
+        model = SampleDisposalEvent
+
+    id = masql.auto_field()
+    reason = EnumField(DisposalReason)
+
+
+basic_sample_disposal_event_schema = BasicSampleDiposalEventSchema()
 
 class BasicSampleDisposalSchema(masql.SQLAlchemySchema):
     class Meta:

--- a/services/web/app/sample/views/sample.py
+++ b/services/web/app/sample/views/sample.py
@@ -24,6 +24,7 @@ from . import (
     SampleProtocolEventSchema,
     BasicSampleDisposalSchema,
     ConsentSchema,
+    BasicSampleDiposalEventSchema,
     SampleReviewSchema,
     EntityToStorageSchema,
 )
@@ -116,6 +117,8 @@ class SampleSchema(masql.SQLAlchemySchema):
     author = ma.Nested(BasicUserAccountSchema, many=False)
 
     protocol_events = ma.Nested(SampleProtocolEventSchema, many=True)
+
+    disposal_event = ma.Nested(BasicSampleDiposalEventSchema, many=False)
 
     disposal_information = ma.Nested(BasicSampleDisposalSchema, many=False)
     consent_information = ma.Nested(ConsentSchema, many=False)

--- a/services/web/app/static/js/sample/disposal/check.js
+++ b/services/web/app/static/js/sample/disposal/check.js
@@ -1,0 +1,29 @@
+/*
+Copyright (C) 2020 Keiron O'Shea <keo7@aber.ac.uk>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+$(document).ready(function () {
+    var sample_uuid = $("#sample-uuid").text();
+
+    $("#form-check").on("input", function(){
+        if (sample_uuid == $(this).val()) {
+            $("#submit").prop('disabled', false)
+        }
+        else {
+            $("#submit").prop('disabled', true)
+        }
+    });
+});

--- a/services/web/app/static/js/sample/view.js
+++ b/services/web/app/static/js/sample/view.js
@@ -62,7 +62,6 @@ function get_barcode(sample_info, barc_type) {
 }
 
 
-
 function fill_title(sample) {
 
     var author_information = sample["author"];

--- a/services/web/app/templates/sample/disposal/new.html
+++ b/services/web/app/templates/sample/disposal/new.html
@@ -12,7 +12,7 @@
     </div>
 </div>
 <div class="container">
-    <form method="POST" action="{{ url_for('sample.dispose', uuid=sample.uuid ) }}"></form>
+    <form method="POST" action="{{ url_for('sample.dispose', uuid=sample.uuid ) }}">
         {{ form.csrf_token }}
         {{ form_field(form.protocol_id) }}
 
@@ -27,39 +27,49 @@
 
         {{ form_field(form.undertaken_by) }}
 
-        
-
-        <button type="button" class="btn btn-success float-right" data-toggle="modal" data-target="#submit-modal">
-            <i class="fa fa-check"></i> Submit
-        </button>
-
-
-
-
-<div class="modal modal-large fade" id="submit-modal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+<!-- Button trigger modal -->
+<button type="button" class="btn btn-warning float-right" data-toggle="modal" data-target="#sample-disposal-modal">
+    Stage Disposal
+  </button>
+  
+  <!-- Modal -->
+  <div class="modal fade" id="sample-disposal-modal" tabindex="-1" role="dialog" aria-labelledby="sample-disposal-modal-title" aria-hidden="true">
     <div class="modal-dialog" role="document">
       <div class="modal-content">
         <div class="modal-header bg-danger text-white">
-          <h5 class="modal-title" id="exampleModalLabel">Submit Disposal Event</h5>
+          <h5 class="modal-title" id="sample-disposal-modal-title">Confirm Sample Destruction</h5>
           <button type="button" class="close" data-dismiss="modal" aria-label="Close">
             <span aria-hidden="true">&times;</span>
           </button>
         </div>
         <div class="modal-body">
-            <p><b>Warning:</b> Please ensure that you want to dispose of: <br> <a href="{{ sample._links.self }}">
-                <i class="fas fa-vial"></i> <span id="sample-uuid">{{ sample.uuid }}</span></a>
+            <div class="alert alert-danger" role="alert">
+                <b>Warning:</b> This is irreversable, please double check that you are removing the correct sample before
+                continuing!
+            </div>
+
+            <p>To double check, please enter the Sample's UUID below:</p>
+            <input type="text" id="form-check" class="form-control"></input>
         </div>
         <div class="modal-footer">
-          <button type="button" class="btn btn-secondary" data-dismiss="modal">Close Dialog</button>
-          <button type="button" type="submit" class="btn  btn-success" data-dismiss="modal"><i class="fa fa-check"></i> Submit</button>
-
+          <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+          <button type="submit" class="btn btn-success" id="submit" disabled style="margin: 0px;">
+            <i class="fa fa-check"></i> Submit
+        </button>
         </div>
       </div>
     </div>
   </div>
 
+
 </form>
 
 
+
 </div>
+{% endblock %}
+
+
+{% block javascript %}
+<script src="{{ url_for('static', filename='js/sample/disposal/check.js') }}"></script>
 {% endblock %}

--- a/services/web/app/templates/sample/disposal/new.html
+++ b/services/web/app/templates/sample/disposal/new.html
@@ -8,7 +8,7 @@
         <h1><span class="secondary-heading">
             <a href="{{ sample._links.self }}">
                 <i class="fas fa-vial"></i> <span id="sample-uuid">{{ sample.uuid }}</span></a></span>
-        <i class="fa fa-trash"></i> New Sample Dipsosal Event </h1>
+        <i class="fa fa-trash"></i> New Sample Disposal Event </h1>
     </div>
 </div>
 <div class="container">

--- a/services/web/app/templates/sample/disposal/new.html
+++ b/services/web/app/templates/sample/disposal/new.html
@@ -8,25 +8,32 @@
         <h1><span class="secondary-heading">
             <a href="{{ sample._links.self }}">
                 <i class="fas fa-vial"></i> <span id="sample-uuid">{{ sample.uuid }}</span></a></span>
-        <i class="fa fa-trash"></i> Sample Dipsosal </h1>
+        <i class="fa fa-trash"></i> New Sample Dipsosal Event </h1>
     </div>
 </div>
 <div class="container">
     <form method="POST" action="{{ url_for('sample.dispose', uuid=sample.uuid ) }}"></form>
         {{ form.csrf_token }}
+        {{ form_field(form.protocol_id) }}
 
-        {{ form_field(form.instruction) }}
+        {{ form_field(form.reason) }}
         {{ form_field(form.comments) }}
 
-        {{ form_field(form.time) }}
-        {{ form_field(form.date) }}
+        <div class="row">
+            <div class="col-6">{{ form_field(form.date) }}</div>
+            <div class="col-6">{{ form_field(form.time) }}</div>
+
+        </div>
+
+        {{ form_field(form.undertaken_by) }}
+
+        
 
         <button type="button" class="btn btn-success float-right" data-toggle="modal" data-target="#submit-modal">
             <i class="fa fa-check"></i> Submit
         </button>
 
 
-    </form>
 
 
 <div class="modal modal-large fade" id="submit-modal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
@@ -39,19 +46,20 @@
           </button>
         </div>
         <div class="modal-body">
-            <p><b>Warning:</b> Please ensure that you want to dispose of <a href="{{ sample._links.self }}">
+            <p><b>Warning:</b> Please ensure that you want to dispose of: <br> <a href="{{ sample._links.self }}">
                 <i class="fas fa-vial"></i> <span id="sample-uuid">{{ sample.uuid }}</span></a>
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-dismiss="modal">Close Dialog</button>
-          <button type="button" class="btn  btn-success" data-dismiss="modal"><i class="fa fa-check"></i> Submit</button>
+          <button type="button" type="submit" class="btn  btn-success" data-dismiss="modal"><i class="fa fa-check"></i> Submit</button>
 
         </div>
       </div>
     </div>
   </div>
 
-        
+</form>
+
 
 </div>
 {% endblock %}

--- a/services/web/app/templates/sample/disposal/new.html
+++ b/services/web/app/templates/sample/disposal/new.html
@@ -7,11 +7,51 @@
     <div class="container">
         <h1><span class="secondary-heading">
             <a href="{{ sample._links.self }}">
-                <i class="fas fa-vial"></i> {{ sample.uuid }}</a></span>
+                <i class="fas fa-vial"></i> <span id="sample-uuid">{{ sample.uuid }}</span></a></span>
         <i class="fa fa-trash"></i> Sample Dipsosal </h1>
     </div>
 </div>
 <div class="container">
+    <form method="POST" action="{{ url_for('sample.dispose', uuid=sample.uuid ) }}"></form>
+        {{ form.csrf_token }}
+
+        {{ form_field(form.instruction) }}
+        {{ form_field(form.comments) }}
+
+        {{ form_field(form.time) }}
+        {{ form_field(form.date) }}
+
+        <button type="button" class="btn btn-success float-right" data-toggle="modal" data-target="#submit-modal">
+            <i class="fa fa-check"></i> Submit
+        </button>
+
+
+    </form>
+
+
+<div class="modal modal-large fade" id="submit-modal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header bg-danger text-white">
+          <h5 class="modal-title" id="exampleModalLabel">Submit Disposal Event</h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body">
+            <p><b>Warning:</b> Please ensure that you want to dispose of <a href="{{ sample._links.self }}">
+                <i class="fas fa-vial"></i> <span id="sample-uuid">{{ sample.uuid }}</span></a>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-dismiss="modal">Close Dialog</button>
+          <button type="button" class="btn  btn-success" data-dismiss="modal"><i class="fa fa-check"></i> Submit</button>
+
+        </div>
+      </div>
+    </div>
+  </div>
+
+        
 
 </div>
 {% endblock %}

--- a/services/web/app/templates/sample/index.html
+++ b/services/web/app/templates/sample/index.html
@@ -30,6 +30,7 @@
             {{ form_field(form.type) }}
             {{ form_field(form.colour) }}
             {{ form_field(form.source) }}
+
             {{ form_field(form.status) }}
 
             <div class="row">


### PR DESCRIPTION
## Description

This PR adds rudimentary Sample Disposal Event functionality. 

Fixes #69 (Nice)

When you go into an available Sample, you should now see an option to Dispose of a Sample:

![image](https://user-images.githubusercontent.com/4386515/119348660-14337e00-bc95-11eb-9d10-be170d85d01b.png)

This takes you to the following form:

![image](https://user-images.githubusercontent.com/4386515/119348704-26152100-bc95-11eb-9a9b-d2a85b7fdda3.png)

As a validation step, the user is asked to copy and paste in the UUID to confirm that they want to dispose of the Sample:

![image](https://user-images.githubusercontent.com/4386515/119348808-447b1c80-bc95-11eb-9027-9841784b2b3a.png)

I still need to add a lot, it might be advisable to ask the user if they want to have all relatives destroyed - but that's a fair bit of a task as we could be in situations where the Sample may already been transferred or whatever. I'll need to think about it a bit before implementing.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
