### PR TITLE
User is now asked to confirm when a Protocol Event is to be disposed.

### DIFF
--- a/services/web/app/static/js/sample/view.js
+++ b/services/web/app/static/js/sample/view.js
@@ -265,6 +265,9 @@ function fill_sample_reviews(reviews) {
 
 
 function fill_protocol_events(events) {
+
+    let protocol_events = new Map();
+
     for (e in events) {
         var event_info = events[e];
 
@@ -284,7 +287,7 @@ function fill_protocol_events(events) {
         html += "<h1><i class='fa fa-project-diagram'></i></h1>"
         html += "</div>"
         html += "<div class='media-body'>"
-        html += "<h5 class='mt-0'>" + event_info["uuid"] + "</h5>";
+        html += "<h5 class='mt-0' id='protocol-uuid-" + event_info["id"] +"'>" + event_info["uuid"] + "</h5>";
         html += "<a href='"+ event_info["protocol"]["_links"]["self"] +"'>"
         html += "<h6 class='mt-0'>LIMBPRO-" + event_info["protocol"]["id"] + ": " + event_info["protocol"]["name"] + "</h6>";
         html += "</a>"
@@ -294,6 +297,7 @@ function fill_protocol_events(events) {
         html += "</table>"
         html += "</div>"
 
+
         html += "</div>"
         // End card body
         html += "</div>"
@@ -301,17 +305,44 @@ function fill_protocol_events(events) {
         html += "<a href='" + event_info["_links"]["edit"] + "'>"
         html += "<div class='btn btn-warning float-left'>Edit</div>"
         html += "</a>"
-        html += "<a href='" + event_info["_links"]["remove"] + "'>"
-        html += "<div class='btn btn-danger float-right disabled'>Remove</div>"
-        html += "</a>"
+
+        html += "<div id='remove-protocol-"+event_info["id"] + "' class='btn btn-danger float-right'>Remove</div>"
         html += "</div>"
         html += "</div>"
 
-    
+        
+        protocol_events.set(event_info["id"].toString(), event_info);
+        
         // End ul
         html += "</li>"
-
         $("#protocol-event-li").append(html);
+
+        $("#remove-protocol-"+event_info["id"]).on("click", function () {
+            var id = $(this).attr("id").split("-")[2];
+            
+            var uuid = $("#protocol-uuid-"+id).text();
+            $("#delete-protocol-confirm-modal").modal({
+                show: true
+            });
+
+            var removal_link = protocol_events.get(id)["_links"]["remove"];
+
+            $("#protocol-uuid-remove-confirmation-input").on("change", function() {
+                var user_entry = $(this).val();
+                if (user_entry == uuid) {
+                    $("#protocol-remove-confirm-button").prop("disabled", false);
+                    $('#protocol-remove-confirm-button').click(function() {
+                        window.location.href = removal_link;
+                    });
+                } 
+                else {
+                    $("#protocol-remove-confirm-button").prop("disabled", true);
+
+                }
+            })
+        });
+
+
     }
 }
 

--- a/services/web/app/templates/sample/view.html
+++ b/services/web/app/templates/sample/view.html
@@ -194,6 +194,55 @@
 </div>
 
 
+
+<div class="modal fade" id="delete-protocol-event-confirm" tabindex="-1" role="dialog" aria-labelledby="delete-protocol-event-confirm-label" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header bg-danger text-white">
+        <h5 class="modal-title" id="delete-protocol-event-confirm-label">Modal title</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        ...
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+        <button type="button" class="btn btn-primary">Save changes</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+<!-- Delete Protocol Modal -->
+<div class="modal fade" id="delete-protocol-confirm-modal" tabindex="-1" role="dialog" aria-labelledby="delete-protocol-confirm-modal-title" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered" role="document">
+    <div class="modal-content">
+      <div class="modal-header bg-danger text-white">
+        <h5 class="modal-title" id="delete-protocol-confirm-modal-title">Confirm Protocol Event Removal</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <div class="alert alert-danger" role="alert">
+          <B>Warning:</B> This action cannot be undone!
+        </div>
+        <p>Please enter the Protocol Event UUID to confirm that you want to remove this Event:</p>
+        <input type="text" class="form-control" id="protocol-uuid-remove-confirmation-input"></input>
+
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">Dismiss</button>
+        <button type="button" id="protocol-remove-confirm-button" class="btn btn-success" disabled>Confirm</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+
 <!-- Consent Modal -->
 <div class="modal fade bd-example-modal-lg" id="consentModal" tabindex="-1" role="dialog"
   aria-labelledby="consentModalLabel" aria-hidden="true">


### PR DESCRIPTION
## Description

Client complained about the immediate nature in which Protocol Events are removed, this PR resolves that by adding a modal:

![image](https://user-images.githubusercontent.com/4386515/119484081-91222e80-bd4d-11eb-8bea-c9d3700fa7e6.png)

When the Remove button is pressed. The user is shown a modal asking for them to write in the Protocol Event UUID:

![image](https://user-images.githubusercontent.com/4386515/119484151-a303d180-bd4d-11eb-885d-dc4164b8db18.png)

Once the UUID is entered, the user is then able to continue with the removal.

Fixes #78

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
