### PR TITLE
CVE fixes

### DIFF
--- a/services/web/package.json
+++ b/services/web/package.json
@@ -11,7 +11,7 @@
         "@fortawesome/fontawesome-free": "^5.12.0",
         "bootstrap": "4.3.1",
         "bootstrap-select": "^1.13.17",
-        "chart.js": "2.9.3",
+        "chart.js": ">=2.9.4",
         "chartjs-adapter-moment": "0.1.1",
         "d3": "5.15.0",
         "datatables.net-bs4": "1.10.20",

--- a/services/web/requirements.txt
+++ b/services/web/requirements.txt
@@ -10,7 +10,7 @@ cffi==1.14.3
 chardet==3.0.4
 click==7.1.2
 coverage==5.3
-cryptography==3.0
+cryptography==3.2
 cssselect2==0.4.1
 decorator==4.4.2
 defusedxml==0.6.0
@@ -43,7 +43,7 @@ nanoset==0.1.4
 networkx==2.4
 nose2==0.9.2
 Owlready2==0.25
-Pillow==7.1.2
+Pillow==8.3.2
 pronto==2.1.0
 psycopg2-binary==2.8.5
 pycountry==19.8.18
@@ -56,7 +56,7 @@ python-barcode==0.13.1
 python-dateutil==2.8.1
 python-editor==1.0.4
 pyxdg==0.25
-PyYAML==5.3.1
+PyYAML>=5.4
 qrcode==6.1
 requests==2.24.0
 SecretStorage==2.3.1
@@ -67,7 +67,7 @@ SQLAlchemy-Utils==0.36.5
 tinycss2==1.1.0
 treepoem==3.3.1
 uk-postcode-utils==1.0
-urllib3==1.25.11
+urllib3>=1.26.5
 WeasyPrint==52.2
 webargs==6.1.0
 webencodings==0.5.1


### PR DESCRIPTION
# Backported CVE fixes

This PR mainlines CVE fixes from our instances:

### urllib3

When provided with a URL containing many `@` characters in the authority component the authority regular expression exhibits catastrophic backtracking causing a denial of service if a URL were passed as a parameter or redirected to via an HTTP redirect.

Fix: urllib3>=1.26.5

### chart.js

This affects the package chart.js before 2.9.4. The options parameter is not properly sanitized when it is processed. When the options are processed, the existing options (or the defaults options) are deeply merged with provided options. However, during this operation, the keys of the object being set are not checked, leading to a prototype pollution.

### PyYAML

A vulnerability was discovered in the PyYAML library in versions before 5.4, where it is susceptible to arbitrary code execution when it processes untrusted YAML files through the full_load method or with the FullLoader loader. Applications that use the library to process untrusted input may be vulnerable to this flaw. This flaw allows an attacker to execute arbitrary code on the system by abusing the python/object/new constructor. This flaw is due to an incomplete fix for CVE-2020-1747.

Fix: PyYAML>=5.4

### Pillow

- Pillow through 8.2.0 and PIL (aka Python Imaging Library) through 1.1.7 allow an attacker to pass controlled parameters directly into a convert function to trigger a buffer overflow in Convert.c.
- The package pillow from 0 and before 8.3.2 are vulnerable to Regular Expression Denial of Service (ReDoS) via the getrgb function.
- An issue was discovered in Pillow before 8.2.0. For EPS data, the readline implementation used in EPSImageFile has to deal with any combination of \r and \n as line endings. It used an accidentally quadratic method of accumulating lines while looking for a line ending. A malicious EPS file could use this to perform a DoS of Pillow in the open phase, before an image was accepted for opening.
- An issue was discovered in Pillow before 8.2.0. PSDImagePlugin.PsdImageFile lacked a sanity check on the number of input layers relative to the size of the data block. This could lead to a DoS on Image.open prior to Image.load.
- An issue was discovered in Pillow before 8.2.0. For FLI data, FliDecode did not properly check that the block advance was non-zero, potentially leading to an infinite loop on load.
- An issue was discovered in Pillow before 8.2.0. There is an out-of-bounds read in J2kDecode, in j2ku_gray_i. This dates to Pillow 2.4.0.
- An issue was discovered in Pillow before 8.2.0. There is an out-of-bounds read in J2kDecode, in j2ku_graya_la.
- An issue was discovered in Pillow before 8.2.0. For BLP data, BlpImagePlugin did not properly check that reads (after jumping to file offsets) returned data. This could lead to a DoS where the decoder could be run a large number of times on empty data.
- Pillow before 8.1.1 allows attackers to cause a denial of service (memory consumption) because the reported size of a contained image is not properly checked for a BLP container, and thus an attempted memory allocation can be very large.
- In Pillow before 8.1.0, SGIRleDecode has a 4-byte buffer over-read when decoding crafted SGI RLE image files because offsets and length tables are mishandled.
- Pillow before 8.1.1 allows attackers to cause a denial of service (memory consumption) because the reported size of a contained image is not properly checked for a BLP container, and thus an attempted memory allocation can be very large.
-  Pillow before 8.1.1 allows attackers to cause a denial of service (memory consumption) because the reported size of a contained image is not properly checked for an ICNS container, and thus an attempted memory allocation can be very large.

Fix: Pillow==8.3.2

### cryptography

RSA decryption was vulnerable to Bleichenbacher timing vulnerabilities, which would impact people using RSA decryption in online scenarios.

Fix: cryptography>=3.2

### pyxdg

A code injection issue was discovered in PyXDG before 0.26 via crafted Python code in a Category element of a Menu XML document in a .menu file. XDG_CONFIG_DIRS must be set up to trigger xdg.Menu.parse parsing within the directory containing this file. This is due to a lack of sanitization in xdg/Menu.py before an eval call.

Fix: pyxdg>=0.26


