### PR TITLE
Nudged node to 14

### DIFF
--- a/services/web/Dockerfile
+++ b/services/web/Dockerfile
@@ -1,10 +1,10 @@
 FROM ubuntu:18.04
 
-MAINTAINER "Keiron O'Shea <keo7@aber.ac.uk>"
+LABEL authors="Keiron O'Shea <keo7@aber.ac.uk>, Chuan Lu <cul@aber.ac.uk>"
 
 RUN apt-get update && apt-get install -y curl 
 
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - \
     && apt-get install -y nodejs
 
 RUN apt-get -y install python3 python3-pip python3-wheel python3-setuptools \ 


### PR DESCRIPTION
## Description

Previous Dockerfile was running NodeJS 10, which has long been unsupported. Nudged it to 14 which is the LTS version.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
