### PR TITLE
fixed storage navtree button, no longer disappears when hiding pane

### DIFF
--- a/services/web/app/static/css/storage/navbar.css
+++ b/services/web/app/static/css/storage/navbar.css
@@ -7,8 +7,6 @@
 #sidebar {
     min-width: 20em;
     max-width: 20em;
-    height: 100%;
-    min-height: 100vh;
     overflow: auto;
     top: 30px;
     left: 0;
@@ -21,12 +19,10 @@
 }
 
 #sidebar-collapse {
-    float: right;
-    margin: 0;
     z-index: 998;
     position: relative;
-    margin-top: 50%;
-    right: -1em;
+    left: -1em;
+    width: 0;
 }
 
 #sidebar-collapse button {
@@ -36,6 +32,10 @@
 
 #sidebar.active #sidebar-collapse {
     right: -3em;
+}
+
+.storage .container {
+  margin-left: 3em;
 }
 
 /* The Modal (background) */

--- a/services/web/app/static/js/storage/navtree.js
+++ b/services/web/app/static/js/storage/navtree.js
@@ -88,16 +88,12 @@ function collapse_sidebar() {
         $('#sidebar').toggleClass('active');
         $('#sidebar-collapse-icon').toggleClass('fa-chevron-left');
         $('#sidebar-collapse-icon').toggleClass('fa-chevron-right');
-        $('#sidebar-collapse button').toggleClass('btn-light');
-        $('#sidebar-collapse button').toggleClass('btn-primary');
 }
 
 function open_sidebar() {
     $('#sidebar').toggleClass('false');
     $('#sidebar-collapse-icon').toggleClass('fa-chevron-left');
     $('#sidebar-collapse-icon').toggleClass('fa-chevron-right');
-    $('#sidebar-collapse button').toggleClass('btn-light');
-    $('#sidebar-collapse button').toggleClass('btn-primary');
 }
 
 $(function() {

--- a/services/web/app/templates/macros.html
+++ b/services/web/app/templates/macros.html
@@ -277,10 +277,10 @@
     <div id="sidebar" class="text-white bg-primary">
         <div id="jstree">
         </div>
-        <div id="sidebar-collapse" class="align-self-center">
-            <button class="btn btn-lg btn-block btn-light">
-                <i id="sidebar-collapse-icon" class="fa fa-chevron-left"></i>
-            </button>
-        </div>
+    </div>
+    <div id="sidebar-collapse" class="align-self-center">
+        <button class="btn btn-lg btn-block btn-light">
+            <i id="sidebar-collapse-icon" class="fa fa-chevron-left"></i>
+        </button>
     </div>
     {% endmacro %}


### PR DESCRIPTION
## Description

The button to hide the navtree in the storage pages no longer disappears when clicked.

Fixes #113 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
