### PR TITLE
 fix/sqlalchemy-versions-deprecated

### DIFF
--- a/services/web/requirements.txt
+++ b/services/web/requirements.txt
@@ -62,7 +62,7 @@ requests==2.24.0
 SecretStorage==2.3.1
 six==1.14.0
 SQLAlchemy==1.3.16
-SQLAlchemy-Continuum==1.3.9
+SQLAlchemy-Continuum==1.3.12
 SQLAlchemy-Utils==0.36.5
 tinycss2==1.1.0
 treepoem==3.3.1


### PR DESCRIPTION
## Description

This seems to fix the versioning issues when using `sqlalchemy-continuum` with `sqlalchemy` >= 1.4

Fixes #106

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)